### PR TITLE
Logic changes to warn user of possible game deletions

### DIFF
--- a/lib/src/pages/actions/actions_model.dart
+++ b/lib/src/pages/actions/actions_model.dart
@@ -1,6 +1,61 @@
 import 'dart:io';
 
-void migrate() {
-  print("Migrating...");
-  Process.run("\$SNAP/bin/steam-snap.sh", []).then((value) => {print("Migrated library.")});
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:steam_tweaks/widgets.dart';
+import 'package:provider/provider.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
+import 'package:yaru_icons/yaru_icons.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
+import 'actions_model.dart';
+
+void migrate(BuildContext context, String method) async {
+  final String steamGamesDirectory = "${Platform.environment['HOME']}/snap/steam/common/.local/share/Steam/steamapps/common";
+  if(method == "copy"){
+    print("Copied to snap!");
+    //copy deb games [check if we only need to copy steamapps/common] to snap
+  } else {
+    final bool hasDownloadedGames = await Directory(steamGamesDirectory).exists();
+    if(!hasDownloadedGames){
+      //this is the idea, but not working
+      //Process.run("\$SNAP/bin/steam-snap.sh", []).then((value) => {print("Linked library.")});
+      print("This should link library!");
+    } else {
+      final bool? choice = await showAlertDialog(context);
+      if(choice!=null && choice){
+        //this is the idea, but not working
+        //Directory("${Platform.environment['HOME']}/snap/steam/common/.local/share/Steam/steamapps").delete(recursive: true);
+        //Process.run("\$SNAP/bin/steam-snap.sh", []).then((value) => {print("Linked library.")});
+        print("You chose to delete your snap steam games and link the deb");
+      }
+    }
+  }
+}
+
+Future <bool?> showAlertDialog(BuildContext context) async {
+  return showDialog<bool>(
+    context: context,
+    barrierDismissible: false,
+    builder: (BuildContext context) {
+      return AlertDialog(
+        title: const Text("You have downloaded games in the snap!"),
+        content: const Text(
+            "Migrating your library with the link method will delete your steam snap library. Are you sure you want to proceed?"),
+        actions: <Widget>[
+          TextButton(
+            child: const Text('Cancel'),
+            onPressed: () {
+              Navigator.of(context,rootNavigator:true).pop(false);
+            },
+          ),
+          TextButton(
+            child: const Text('Continue'),
+            onPressed: () {
+              Navigator.of(context,rootNavigator:true).pop(true);
+            },
+          )
+        ],
+      );
+    },
+  );
 }

--- a/lib/src/pages/actions/actions_page.dart
+++ b/lib/src/pages/actions/actions_page.dart
@@ -49,24 +49,24 @@ class _ActionsPageState extends State<ActionsPage> {
         child: Center(
           child: Column(
             children: [
-              Spacer(),
+              const Spacer(),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 mainAxisSize: MainAxisSize.max,
                 children: [
-                  Text("Would you like to migrate your library?"),
+                  const Text("Would you like to migrate your library?"),
                   Column(
                     children: [
                       ElevatedButton(
                         child: const Text("Migrate (copy)"),
                         onPressed: () {
-                          migrate();
+                          migrate(context, "copy");
                         },
                       ),
                       ElevatedButton(
                         child: const Text("Migrate (link)"),
                         onPressed: () {
-                          migrate();
+                          migrate(context, "link");
                         },
                       ),
                     ],


### PR DESCRIPTION
No need to merge now, just wanted to check if this makes sense.
Linking snap library when you have games should only be done if the user understands the consequences, so I added an alert dialog. I just need to make sure it has the correct UI format.
The actual backend instructions are commented out, some of them won't work (I'm investigating why). But please let me know if those make sense as well.